### PR TITLE
added: browserslist

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,10 @@
     "fix": "run-p --print-label fix:*",
     "fix:eslint": "yarn lint:eslint --fix"
   },
+  "browserslist": [
+    "last 2 Chrome version",
+    "Firefox ESR"
+  ],
   "dependencies": {
     "moment": "^2.24.0"
   },


### PR DESCRIPTION
parcelが知らぬうちに見ているらしい.
ChromeとFirefox向けにしかリリースしていないのでこの指定で問題ない.