### PR TITLE
fix: GitHubのissueなどの基本表記に対応 closed #72

### DIFF
--- a/src/GitHub.ts
+++ b/src/GitHub.ts
@@ -8,9 +8,9 @@ export default class GitHub extends Site {
     // issueの書き込み時間
     GitHub.relativeTimes().forEach((relativeTime) => {
       if (relativeTime instanceof HTMLElement) {
-        const title = relativeTime.getAttribute("title");
-        if (title) {
-          relativeTime.innerText = title;
+        const datetime = relativeTime.getAttribute("datetime");
+        if (typeof datetime === "string") {
+          relativeTime.outerText = dayjs(datetime).format();
         }
       }
     });

--- a/src/Site.ts
+++ b/src/Site.ts
@@ -34,12 +34,12 @@ export default abstract class Site {
 
   /** ページに変更が入ったら呼び出されます。 */
   run = (): void => {
-    // 監視を中断し,
+    // 監視を中断します。
     this.observers.forEach((observer) => observer.disconnect());
     this.observers = [];
-    // 全画面の書き換えを行い,
+    // 全画面の書き換えを行います。
     this.replace();
-    // 監視を再開する
+    // 監視を再開します。
     this.observe();
   };
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -45,7 +45,7 @@ function detect(): Site | undefined {
 /** エントリーポイントにする関数です。 */
 function main(): void {
   const site = detect();
-  if (site) {
+  if (site != null) {
     site.init();
   }
 }


### PR DESCRIPTION
[github/relative-time-element: Web component extensions to the standard <time> element.](https://github.com/github/relative-time-element) が使われるようになって`title`が既にアメリカ限定ローカライズドされたものになってしまっていました。 `datetime`を使います。
ISO剥き出しの表記で良いかはよく分かりませんが、
少なくともUS表記よりはマシだと判断しました。