### PR TITLE
fix: GitHubでのファイル更新日時など相対表記はそのままで地域のフォーマットを使うように変更 closed #90

### DIFF
--- a/src/GitHub.ts
+++ b/src/GitHub.ts
@@ -8,10 +8,7 @@ export default class GitHub extends Site {
     // issueの書き込み時間
     GitHub.relativeTimes().forEach((relativeTime) => {
       if (relativeTime instanceof HTMLElement) {
-        const datetime = relativeTime.getAttribute("datetime");
-        if (typeof datetime === "string") {
-          relativeTime.outerText = dayjs(datetime).format();
-        }
+        relativeTime.setAttribute("lang", window.navigator.languages[0]);
       }
     });
     // コミット履歴の区切り


### PR DESCRIPTION
GitHubの`RelativeTimeElement`を読み込んで、
要素の`lang`属性をフォーマットに使うことを確認して使用しました。