### PR TITLE
build: なるべく余計なファイルが入りにくいようにします

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "lint:prettier": "prettier --ignore-unknown --check '**/*.{js,jsx,ts,tsx,json,html,css,less,sass,scss,yml,yaml}'",
     "lint:tsc": "tsc --noEmit",
     "lint:web-ext": "web-ext lint",
-    "package": "yarn build --no-source-maps && web-ext build && yarn archive",
+    "package": "rm -rf dist/ && yarn build --no-source-maps && web-ext build && yarn archive",
     "start": "web-ext run",
     "watch": "parcel watch src/main.ts"
   },

--- a/web-ext-config.js
+++ b/web-ext-config.js
@@ -4,7 +4,10 @@ module.exports = {
     filename: "goodbye-rfc-2822-date-time.zip",
   },
   ignoreFiles: [
+    "**/*.map",
+    "*.tar.gz",
     "README.md",
+    "build",
     "package.json",
     "src",
     "tsconfig.json",


### PR DESCRIPTION
対処療法がすぎると思うので、
素直に、
[自動デプロイ · Issue #40 · ncaq/goodbye-rfc-2822-date-time](https://github.com/ncaq/goodbye-rfc-2822-date-time/issues/40) を行ったほうが良いと思います。