### PR TITLE
ci: dependabotの対処を楽にする

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,11 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 20
+    groups:
+      eslint:
+        patterns:
+          - "*eslint*"
     labels:
       - "Status: Review Needed"
       - "Type: Dependencies"


### PR DESCRIPTION
* dependabotが一度にPRを多く開けるようにして毎週対処必須なのを軽減
* eslint関係パッケージは明らかに相互にバージョンを同期しているのでPRをまとめます