### PR TITLE
ci: dependabotの更新負担を減らす

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     labels:
       - "Status: Review Needed"
       - "Type: Dependencies"
@@ -13,7 +13,7 @@ updates:
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     open-pull-requests-limit: 20
     groups:
       eslint:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,9 @@ updates:
       interval: "monthly"
     open-pull-requests-limit: 20
     groups:
+      types:
+        patterns:
+          - "@types*"
       eslint:
         patterns:
           - "*eslint*"


### PR DESCRIPTION
そんなに頻繁にリリースするプロジェクトではないので週1で更新が来るのは面倒なことに気が付きました。