### PR TITLE
ci: typesのpatternを修正

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,7 +18,7 @@ updates:
     groups:
       types:
         patterns:
-          - "@types*"
+          - "@types/*"
       eslint:
         patterns:
           - "*eslint*"


### PR DESCRIPTION
typescript-eslintなどが引っかかってしまうことがあるため。